### PR TITLE
Remove non-MSVC definitions of ssize_t for Windows

### DIFF
--- a/wasm2c/wasm-rt-wasi.c
+++ b/wasm2c/wasm-rt-wasi.c
@@ -48,12 +48,6 @@ typedef double f64;
 #ifdef _MSC_VER
 #include <BaseTsd.h>
 typedef SSIZE_T ssize_t;
-#else // _MSC_VER
-#ifdef _WIN64
-typedef signed long long ssize_t;
-#else // _WIN64
-typedef signed long ssize_t;
-#endif // _WIN64
 #endif // _MSC_VER
 #endif // _WIN32
 


### PR DESCRIPTION
They conflict with the ones from the mingw headers.